### PR TITLE
Cache CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ on:
       - '**'  # Runs on all branches
   pull_request:
 
-env:
-  # These images are arm64 unless specified: https://github.com/actions/runner-images
-  RUNNER_OS: [macos-15] # macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
-
 jobs:
   build:
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # These images are arm64 unless specified: https://github.com/actions/runner-images
+        os: [macos-15] # macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
 
     steps:
     - name: Checkout repository
@@ -64,7 +64,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: dng-env
-        path: /Applications/Adobe\ DNG\ Converter.app
+        path: /tmp/dng-app
+
+    - name: Move to Applications
+      run: |
+        sudo mkdir -p "/Applications/Adobe DNG Converter.app"
+        sudo cp -R /tmp/dng-app/* "/Applications/Adobe DNG Converter.app/"
+        sudo chmod +x "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter"
 
     - name: Verify installation
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ on:
       - '**'  # Runs on all branches
   pull_request:
 
+# YAML anchor for the runner OS
+# These images are arm64 unless specified: https://github.com/actions/runner-images
+# macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # These images are arm64 unless specified: https://github.com/actions/runner-images
-        os: [macos-15] # macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
+    runs-on: &runner-os [macos-15]
 
     steps:
     - name: Checkout repository
@@ -64,7 +64,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ${{ matrix.os }}
+    runs-on: *runner-os
 
     steps:
     - name: Checkout repository
@@ -80,7 +80,9 @@ jobs:
       run: |
         ls -l
         ls -l /Applications
-        sudo cp -R "Adobe DNG Converter.app" /Applications/
+        ls -l /Applications/Adobe\ DNG\ Converter.app
+        ls -l /Applications/Adobe\ DNG\ Converter.app/Contents
+        ls -l /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS
         /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS/Adobe\ DNG\ Converter -d
 
     - name: Test organizeGoProDNG.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,17 @@ jobs:
         printf -- "-Downloading the DNG Converter .dmg file\n"
         curl -L -o DNGConverter_17_5.dmg https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_17_5.dmg
 
+    - name: Cache Adobe DNG Converter.app
+      id: cache-dng-app
+      uses: actions/cache@v3
+      with:
+        path: /Applications/Adobe\ DNG\ Converter.app
+        key: dng-app-17-5
+        restore-keys: |
+          dng-app-
+
     - name: Install Adobe DNG Converter
+      if: steps.cache-dng-app.outputs.cache-hit != 'true'
       run: |
         printf -- "\n\n-Mounting the DMG file\n"
         hdiutil attach DNGConverter_17_5.dmg
@@ -80,10 +90,10 @@ jobs:
       run: |
         ls -l
         ls -l /Applications
-        ls -l /Applications/Adobe\ DNG\ Converter.app
-        ls -l /Applications/Adobe\ DNG\ Converter.app/Contents
-        ls -l /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS
-        /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS/Adobe\ DNG\ Converter -d
+        ls -l "/Applications/Adobe DNG Converter.app"
+        ls -l "/Applications/Adobe DNG Converter.app/Contents"
+        ls -l "/Applications/Adobe DNG Converter.app/Contents/MacOS"
+        "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter" -d
 
     - name: Test organizeGoProDNG.sh
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
-    - name: Cache Adobe DNG Converter DMG
-      id: cache-dmg
-      uses: actions/cache@v3
-      with:
-        path: DNGConverter_17_5.dmg
-        key: dngconverter-17-5
-        restore-keys: |
-          dngconverter-
-
-    - name: Download Adobe DNG Converter
-      if: steps.cache-dmg.outputs.cache-hit != 'true'
-      run: |
-        printf -- "-Downloading the DNG Converter .dmg file\n"
-        curl -L -o DNGConverter_17_5.dmg https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_17_5.dmg
-
     - name: Cache Adobe DNG Converter.app
       id: cache-dng-app
       uses: actions/cache@v3
@@ -42,9 +27,12 @@ jobs:
         restore-keys: |
           dng-app-
 
-    - name: Install Adobe DNG Converter
+    - name: Download and Install Adobe DNG Converter
       if: steps.cache-dng-app.outputs.cache-hit != 'true'
       run: |
+        printf -- "-Downloading the DNG Converter .dmg file\n"
+        curl -L -o DNGConverter_17_5.dmg https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_17_5.dmg
+
         printf -- "\n\n-Mounting the DMG file\n"
         hdiutil attach DNGConverter_17_5.dmg
 
@@ -63,6 +51,7 @@ jobs:
 
     - name: Verify installation
       run: |
+        du -sh /Applications/Adobe*
         /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS/Adobe\ DNG\ Converter -d
 
     - name: Upload installed environment
@@ -90,9 +79,7 @@ jobs:
       run: |
         ls -l
         ls -l /Applications
-        ls -l "/Applications/Adobe DNG Converter.app"
-        ls -l "/Applications/Adobe DNG Converter.app/Contents"
-        ls -l "/Applications/Adobe DNG Converter.app/Contents/MacOS"
+        du -sh /Applications/Adobe*
         "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter" -d
 
     - name: Test organizeGoProDNG.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ on:
       - '**'  # Runs on all branches
   pull_request:
 
+env:
+  # These images are arm64 unless specified: https://github.com/actions/runner-images
+  RUNNER_OS: [macos-15] # macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # These images are arm64 unless specified: https://github.com/actions/runner-images
-        os: [macos-15] # macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
+    runs-on: ${{ env.RUNNER_OS }}
 
     steps:
     - name: Checkout repository
@@ -64,7 +64,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macos-15
+    runs-on: ${{ env.RUNNER_OS }}
 
     steps:
     - name: Checkout repository
@@ -78,6 +78,9 @@ jobs:
 
     - name: Verify installation
       run: |
+        ls -l
+        ls -l /Applications
+        sudo cp -R "Adobe DNG Converter.app" /Applications/
         /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS/Adobe\ DNG\ Converter -d
 
     - name: Test organizeGoProDNG.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,23 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
-    - name: Install Adobe DNG Converter
+    - name: Cache Adobe DNG Converter DMG
+      id: cache-dmg
+      uses: actions/cache@v3
+      with:
+        path: DNGConverter_17_5.dmg
+        key: dngconverter-17-5
+        restore-keys: |
+          dngconverter-
+
+    - name: Download Adobe DNG Converter
+      if: steps.cache-dmg.outputs.cache-hit != 'true'
       run: |
         printf -- "-Downloading the DNG Converter .dmg file\n"
         curl -L -o DNGConverter_17_5.dmg https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_17_5.dmg
 
+    - name: Install Adobe DNG Converter
+      run: |
         printf -- "\n\n-Mounting the DMG file\n"
         hdiutil attach DNGConverter_17_5.dmg
 
@@ -38,6 +50,35 @@ jobs:
 
         printf -- "\n\n-Unmounting the DMG file\n"
         hdiutil detach /Volumes/DNGConverter_17_5
+
+    - name: Verify installation
+      run: |
+        /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS/Adobe\ DNG\ Converter -d
+
+    - name: Upload installed environment
+      uses: actions/upload-artifact@v4
+      with:
+        name: dng-env
+        path: /Applications/Adobe\ DNG\ Converter.app
+        retention-days: 30
+
+  test:
+    needs: build
+    runs-on: macos-15
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    - name: Download installed environment
+      uses: actions/download-artifact@v4
+      with:
+        name: dng-env
+        path: /Applications/Adobe\ DNG\ Converter.app
+
+    - name: Verify installation
+      run: |
+        /Applications/Adobe\ DNG\ Converter.app/Contents/MacOS/Adobe\ DNG\ Converter -d
 
     - name: Test organizeGoProDNG.sh
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ on:
       - '**'  # Runs on all branches
   pull_request:
 
-# YAML anchor for the runner OS
-# These images are arm64 unless specified: https://github.com/actions/runner-images
-# macOS CI is expensive: [macos-14, macos-15, macos-15-intel, macos-26]
 
 jobs:
   build:
-    runs-on: &runner-os [macos-15]
+    # YAML anchor for the runner OS
+    # These images are arm64 unless specified: https://github.com/actions/runner-images
+    # macOS CI is 10x more expensive than linux: https://docs.github.com/en/billing/concepts/product-billing/github-actions
+    runs-on: &runner-os [macos-15]  # [macos-14, macos-15, macos-15-intel, macos-26]
 
     steps:
     - name: Checkout repository
@@ -75,7 +75,7 @@ jobs:
         name: dng-env
         path: /tmp/dng-app
 
-    - name: Move to Applications
+    - name: Move environment to /Applications
       run: |
         sudo mkdir -p "/Applications/Adobe DNG Converter.app"
         sudo cp -R /tmp/dng-app/* "/Applications/Adobe DNG Converter.app/"
@@ -83,9 +83,6 @@ jobs:
 
     - name: Verify installation
       run: |
-        ls -l
-        ls -l /Applications
-        du -sh /Applications/Adobe*
         "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter" -d
 
     - name: Test organizeGoProDNG.sh


### PR DESCRIPTION
In the build stage, we download `Adobe DNG Converter.dmg`, install it, then cache the resulting `.app`.
In the test stage, we pull the cached `.app` to "install it", then we perform our tests.

Implements #7 